### PR TITLE
fixed typo

### DIFF
--- a/top_level/__init__.py
+++ b/top_level/__init__.py
@@ -1,4 +1,4 @@
-TL1 = "this is the top level 1 contstant"
+TL1 = "this is the top level 1 constant"
 
 
 # is this an unwelcome comment?


### PR DESCRIPTION
Hard to believe that PyCharm allowed me to misspell constant incorrectly.

Standards are slipping!!